### PR TITLE
gnss_driverの画面出力をWARN以上に変更

### DIFF
--- a/kyubic_ws/src/driver/gnss_driver/launch/gnss_driver.launch.py
+++ b/kyubic_ws/src/driver/gnss_driver/launch/gnss_driver.launch.py
@@ -1,11 +1,24 @@
 # gnss_launch.py
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 def generate_launch_description():
     """
-    GNSSドライバーノードを起動するためのLaunchDescriptionを生成します。
+    GNSSドライバーノードを起動するためのLaunchDescriptionを生成
     """
+
+    log_level_arg = DeclareLaunchArgument(
+        "log_level",
+        default_value="info",
+        description="Logging level (info, warn, error, etc.)"
+    )
+
+    log_level_config = LaunchConfiguration("log_level")
+
+
+
 
     gnss_node = Node(
         package='gnss_driver',
@@ -13,8 +26,10 @@ def generate_launch_description():
         name='gnss_publisher_node',  # これはノード名
         namespace='driver',             # これが名前空間
         output='screen',
+        arguments=['--ros-args', '--log-level', log_level_config]
     )
 
     return LaunchDescription([
+        log_level_arg,
         gnss_node
     ])


### PR DESCRIPTION
resolve #117 

### Done
- driver.launch.py起動時、gnss_driverの情報で画面が覆われるため、WARN以下の情報を出力しない設定に変更

### その他
