### PR TITLE
PIDの初回計算で起動時からのdtによるサチュレーション対策

### DIFF
--- a/kyubic_ws/src/common/pid_controller/include/pid_controller/p_pid.hpp
+++ b/kyubic_ws/src/common/pid_controller/include/pid_controller/p_pid.hpp
@@ -143,6 +143,18 @@ public:
   * @return master ouput
   */
   double get_master_out();
+
+  /**
+  * @brief Get slave each term
+  * @return slave each term
+  */
+  std::array<double, 3> get_slave_each_term();
+
+  /**
+  * @brief Get dt
+  * @return dt
+  */
+  double get_dt();
 };
 
 }  // namespace pid_controller

--- a/kyubic_ws/src/common/pid_controller/include/pid_controller/pid.hpp
+++ b/kyubic_ws/src/common/pid_controller/include/pid_controller/pid.hpp
@@ -46,6 +46,9 @@ private:
   double pre_p = 0;
   double pre_i = 0;
   double pre_d = 0;
+
+  bool first_run = true;
+
   std::chrono::high_resolution_clock::time_point pre_time =
     std::chrono::high_resolution_clock::now();
 
@@ -57,10 +60,10 @@ public:
   explicit PositionPID(const PositionPIDParameter param);
 
   /**
-   * @brief Reset integral term
+   * @brief Reset pid
    * @return none
    */
-  void reset_integral();
+  void reset();
 
   /**
    * @brief Get each term value of pid
@@ -115,6 +118,10 @@ private:
   double pre_p = 0;
   double pre_d = 0;
   double pre_u = 0;
+  double dt = 0.0;
+
+  bool first_run = true;
+
   std::chrono::high_resolution_clock::time_point pre_time =
     std::chrono::high_resolution_clock::now();
 
@@ -130,6 +137,12 @@ public:
    * @return array(x, y, z)
    */
   std::array<double, 3> get_each_term();
+
+  /**
+   * @brief Get dt
+   * @return double
+   */
+  double get_dt() const;
 
   /**
    * @brief Update PID cycle

--- a/kyubic_ws/src/common/pid_controller/src/p_pid.cpp
+++ b/kyubic_ws/src/common/pid_controller/src/p_pid.cpp
@@ -33,7 +33,7 @@ double PositionP_PID::get_master_out() { return master_out; }
 
 void PositionP_PID::set_param_offset(double offset) { slave_pid_->set_offset(offset); }
 
-void PositionP_PID::reset() { slave_pid_->reset_integral(); }
+void PositionP_PID::reset() { slave_pid_->reset(); }
 
 VelocityP_PID::VelocityP_PID(const VelocityP_PIDParameter & param_)
 : k(param_.k), lo(param_.lo), hi(param_.hi), vpid_param(param_.vpid_param)
@@ -55,5 +55,10 @@ void VelocityP_PID::set_param_offset(double offset) { slave_pid_->set_offset(off
 
 double VelocityP_PID::get_master_out() { return master_out; }
 
+std::array<double, 3> VelocityP_PID::get_slave_each_term() { return slave_pid_->get_each_term(); }
+
+double VelocityP_PID::get_dt() { return slave_pid_->get_dt(); }
+
 void VelocityP_PID::reset() { slave_pid_->reset(); }
+
 }  // namespace pid_controller

--- a/kyubic_ws/src/control/controller/p_pid_controller/include/p_pid_controller/p_pid_controller.hpp
+++ b/kyubic_ws/src/control/controller/p_pid_controller/include/p_pid_controller/p_pid_controller.hpp
@@ -58,6 +58,7 @@ public:
   void pid_z_reset();
   void pid_roll_reset();
   void pid_yaw_reset();
+  void pid_all_reset();
 
   std::array<double, 5> update(std::array<std::array<double, 3>, 5> data);
 };

--- a/kyubic_ws/src/control/controller/p_pid_controller/src/p_pid_controller.cpp
+++ b/kyubic_ws/src/control/controller/p_pid_controller/src/p_pid_controller.cpp
@@ -134,10 +134,18 @@ void P_PIDController::set_roll_offset(double roll_deg)
   pid_roll_->set_param_offset(roll_sf * sin(roll_deg * std::numbers::pi / 180));
 }
 
-void P_PIDController::pid_x_reset() { return pid_x_->reset(); }
-void P_PIDController::pid_y_reset() { return pid_y_->reset(); }
-void P_PIDController::pid_z_reset() { return pid_z_->reset(); }
-void P_PIDController::pid_roll_reset() { return pid_roll_->reset(); }
-void P_PIDController::pid_yaw_reset() { return pid_yaw_->reset(); }
+void P_PIDController::pid_x_reset() { pid_x_->reset(); }
+void P_PIDController::pid_y_reset() { pid_y_->reset(); }
+void P_PIDController::pid_z_reset() { pid_z_->reset(); }
+void P_PIDController::pid_roll_reset() { pid_roll_->reset(); }
+void P_PIDController::pid_yaw_reset() { pid_yaw_->reset(); }
+void P_PIDController::pid_all_reset()
+{
+  pid_x_->reset();
+  pid_y_->reset();
+  pid_z_->reset();
+  pid_roll_->reset();
+  pid_yaw_->reset();
+}
 
 }  // namespace controller


### PR DESCRIPTION
resolve #261 

### Done
- dtのリセット，初回のPID計算は比例のみ

### その他
