### PR TITLE
joy stickの認識名が変わったので対応

### DIFF
--- a/kyubic_ws/src/control/manual/joy_common/config/joy_common.param.yaml
+++ b/kyubic_ws/src/control/manual/joy_common/config/joy_common.param.yaml
@@ -1,6 +1,7 @@
 /**:
   ros__parameters:
-    device_name: "Logicool Dual Action"
+    device_name: "Logitech Gamepad F310"
+    # device_name: "Logicool Dual Action"
     # device_name: "Sony PLAYSTATION(R)3 Controller"  # PS3 有線接続
     # device_name: "PLAYSTATION(R)3 Controller"  # PS3 無線接続
 

--- a/kyubic_ws/src/control/manual/joy_common/src/joy_common.cpp
+++ b/kyubic_ws/src/control/manual/joy_common/src/joy_common.cpp
@@ -85,7 +85,7 @@ void JoyCommon::_joyCallback(const sensor_msgs::msg::Joy::SharedPtr msg)
     joy_msg->buttons.down = msg->buttons[14];
     joy_msg->buttons.left = msg->buttons[15];
     joy_msg->buttons.right = msg->buttons[16];
-  } else if (device_name == "Logicool Dual Action") {
+  } else if (device_name == "Logicool Dual Action" || device_name == "Logitech Gamepad F310") {
     joy_msg->stick.lx = msg->axes[0];
     joy_msg->stick.ly = msg->axes[1];
     joy_msg->stick.rx = msg->axes[2];


### PR DESCRIPTION
resolve #288

### Done
-  前，"Logicool Dual Action"
 - 今，"Logitech Gamepad F310"

### その他
